### PR TITLE
Small improvements to the Tutorials section

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -8,6 +8,6 @@ These tutorials will quickly get you using the ROS Team Workspace.
    :maxdepth: 2
    :numbered:
 
-   quick-start.rst
    setting_up_rtw.rst
+   quick-start.rst
    managing_multiple_workspaces.rst

--- a/docs/tutorials/quick-start.rst
+++ b/docs/tutorials/quick-start.rst
@@ -3,10 +3,13 @@ Quick start with RTW
 ==================================
 .. _tutorial-quick-start:
 
-This tutorial shows use of RosTeamWorkspace for very common use-cases that can
-be done without permanent changes to your environment. First you have to clone
-and source the workspace and then continue with the use-case you are
-interested in:
+This tutorial shows the use of RosTeamWorkspace (RTW) for very common use-cases that can
+be done without permanent changes to your environment.
+
+.. note::
+
+   This tutorial assumes that RTW is already set up and sourced.
+   If that is not the case, please follow the :doc:`setting_up_rtw` tutorial first.
 
 .. toctree::
    :maxdepth: 1
@@ -26,15 +29,6 @@ Docker workspace from ``.repos`` file:
 .. code-block:: bash
 
    rtw workspace create --ros-distro jazzy --docker --repos-containing-repository-url <my_git_url> --repos-branch <my_git_branch_with_repos> --ws-folder my_workspace
-
-Clone, setup and source the RosTeamWorkspace (RTW)
----------------------------------------------------
-.. code-block:: bash
-
-   git clone https://github.com/StoglRobotics/ros_team_workspace.git
-   cd ros_team_workspace/rtwcli/ && pip3 install -r requirements.txt --break-system-packages && cd -
-   source ros_team_workspace/setup.bash
-   setup-auto-sourcing  # Make RosTeamWorkspace automatically sourced when open a new terminal (The best experience)
 
 Create new package in an existing workspace
 --------------------------------------------------------

--- a/docs/tutorials/quick-start.rst
+++ b/docs/tutorials/quick-start.rst
@@ -32,7 +32,7 @@ Docker workspace from ``.repos`` file:
 
 Create new package in an existing workspace
 --------------------------------------------------------
-For more details check :ref:`use-case description <uc-new-package>`.
+For more details, check :ref:`use-case description <uc-new-package>`.
 
 .. code-block:: bash
 
@@ -46,7 +46,7 @@ For more details check :ref:`use-case description <uc-new-package>`.
 
 Create robot description package
 -------------------------------------------------
-For more details check
+For more details, check
 :ref:`use-case description <uc-setup-robot-description>`.
 
 .. warning::
@@ -64,7 +64,7 @@ For more details check
 
 Create robot bringup package
 -----------------------------------------------
-For more details check :ref:`use-case description <uc-setup-robot-bringup>`.
+For more details, check :ref:`use-case description <uc-setup-robot-bringup>`.
 
 .. warning::
    You must have a <my_cool_robot_bringup_package_name> package of
@@ -80,7 +80,7 @@ For more details check :ref:`use-case description <uc-setup-robot-bringup>`.
 
 Setup  ros2_control control hardware
 -------------------------------------------------
-For more details check
+For more details, check
 :ref:`use-case description <uc-setup-ros2-control-hardware>`.
 
 .. warning::
@@ -98,7 +98,7 @@ For more details check
 
 Setup  ros2_control controller
 -----------------------------------------------
-For more details check :ref:`use-case description <uc-setup-ros2-controller>`.
+For more details, check :ref:`use-case description <uc-setup-ros2-controller>`.
 
 .. warning::
    You must have a <my_cool_robot_controller_package_name> package of

--- a/docs/tutorials/setting_up_rtw.rst
+++ b/docs/tutorials/setting_up_rtw.rst
@@ -5,13 +5,13 @@ Setting up RosTeamWorkspace (RTW)
 
 Installation of RTW
 """"""""""""""""""""""""""
-To start using RTW framework clone the repository to any location using:
+To start using the RTW framework, clone the repository to any location using:
 
 .. code-block:: bash
 
    git clone https://github.com/StoglRobotics/ros_team_workspace.git
 
-Install RTW CLI. This is a python-based CLI as for ROS 2 that makes it easier to use:
+Next, we install RTW CLI. This is a Python-based CLI that makes it easier to use RTW. It is mainly used in conjunction with ROS 2:
 
 .. code-block:: bash
 
@@ -19,25 +19,26 @@ Install RTW CLI. This is a python-based CLI as for ROS 2 that makes it easier to
    pip3 install -r requirements.txt --break-system-packages  # since Ubuntu 24.04 is this flag required as we are not using virtual environment
    cd -  # go back to the folder where you cloned the RTW
 
-Source the ``setup.bash``` in the top folder of RTW:
+Then, source the ``setup.bash``` in the top folder of RTW:
 
 .. code-block:: bash
 
    source ros_team_workspace/setup.bash
 
-That's all. You are now set to use RTW. If you want to add auto-sourcing you can simply execute the following command:
+That's all. You are now all set to use RTW. If you want to add auto-sourcing you can simply execute the following command:
 
 .. code-block:: bash
 
    setup-auto-sourcing
 
 
-This is going to configure the RosTeamWorkspace permanently. If you want to revert those changes or prefer to do them by yourself simply follow the next few steps.
+This is going to configure the RTW permanently in the sense, that it will always be sourced when you open a new terminal.
+If you want to revert those changes or prefer to do them by yourself simply follow the next few steps.
 
 Manual auto-sourcing
 """""""""""""""""""""
 
-Add auto-sourcing of configuration to your ``.bashrc`` file by adding the following lines to its end using your favorite text editor (e.g., ``vim`` or ``nano``):
+Add auto-sourcing of configuration to your ``.bashrc`` file by adding the following lines at the end of the file using your favorite text editor (e.g., ``vim`` or ``nano``):
 
 .. code-block:: bash
 

--- a/docs/tutorials/setting_up_rtw.rst
+++ b/docs/tutorials/setting_up_rtw.rst
@@ -1,6 +1,6 @@
-============================
-Setting up RosTeamWorkspace
-============================
+=================================
+Setting up RosTeamWorkspace (RTW)
+=================================
 .. _tutorial-setting-up-rtw:
 
 Installation of RTW


### PR DESCRIPTION
This PR adds small changes to the `Tutorials` that make it slightly easier to follow. It mainly:

- Changes the order so the setup of RTW comes as the first point
- Removes the steps to install RTW from `quick-start.rts` as they are already described in `setting_up_rtw.rst`
- Small text changes to improve on the text quality 

I've tested this locally by building the Sphinx documentation and serving it with a http server.