### PR TITLE
Add guidance on skipping *_bringup for single-cell projects

### DIFF
--- a/docs/guidelines/robot_package_structure.rst
+++ b/docs/guidelines/robot_package_structure.rst
@@ -72,3 +72,47 @@ The here down proposed architecture tries to split the robot's files to minimize
       │       └── <robot_specific_controller>.hpp
       └── src/
           └── <robot_specific_controller>.cpp
+
+Do you need a separate ``*_bringup`` package?
+----------------------------------------------
+
+The split above is for a robot-support repository meant to be reused
+across multiple projects — ``*_bringup`` earns its place there because
+it is the thin, per-project wiring layer on top of otherwise-reusable
+description/hardware-interface packages.
+
+A single-cell, single-scenario project (nothing here is meant to be
+reused elsewhere) doesn't need that separation. Fold the robot
+description, MoveIt setup (SRDF, planning/kinematics YAMLs), launch
+files, and any integration config into one ``*_configuration`` package
+instead:
+
+.. code:: text
+
+  <project_name>_configuration/
+  ├── CMakeLists.txt
+  ├── package.xml
+  ├── config/                    # controllers.yaml, MoveIt planning/kinematics YAMLs, any integration config
+  ├── launch/                    # this project's launch files
+  ├── meshes/
+  ├── rviz/
+  ├── srdf/                      # MoveIt semantic description
+  └── urdf/
+
+Decide by how many launch variants there actually are to orchestrate,
+not by project size:
+
+- **Nothing to orchestrate** (one robot, one scenario): skip
+  ``*_bringup``, use one ``*_configuration`` package as above.
+- **Multiple robots, multiple launch variants (sim/real/offline), or
+  multiple equipment units**: keep a dedicated ``*_bringup`` package —
+  the orchestration itself is real work and earns the package.
+- **Reusable description/hardware-interface packages**: use the full
+  split above; ``*_bringup`` staying thin there is correct, not a
+  smell.
+
+If a ``*_bringup`` package does exist, keep it to launch files and
+config only — no application/business-logic nodes. If it's down to
+one or two launch files and no real config, that's the signal to fold
+it into ``*_configuration`` (or the relevant description package)
+instead of keeping it out of inertia.


### PR DESCRIPTION
## Summary
- The existing `robot_package_structure.rst` targets a reusable robot-support repository, where `*_bringup` is the thin per-project wiring layer on top of otherwise-reusable description/hardware-interface packages.
- Adds a new section covering the other common case: a single-cell, single-scenario project with nothing to reuse elsewhere. There, fold description, MoveIt setup (SRDF, planning/kinematics), launch files, and integration config into one `*_configuration` package instead.
- Decision is based on launch-variant count (how many robots/scenarios/launch modes actually need orchestrating), not project size — surveyed across real b»robotized client project layouts, none of which had this documented anywhere before.
- Also notes the failure mode once a `*_bringup` package exists: keep it launch+config only, no logic nodes; fold it into `*_configuration` if it's down to one or two launch files with no real config.

## Test plan
- [x] Pre-commit hooks pass (doc8, rst directive/inline-code checks, ament_copyright, codespell).
- [x] Reads consistently with the existing document's tone and ASCII-tree style.