### PR TITLE
Fix: forward sim_gazebo/simulation_controllers in load_description.launch.xml

### DIFF
--- a/templates/robot_description/load_description.launch.xml
+++ b/templates/robot_description/load_description.launch.xml
@@ -34,11 +34,17 @@ Author: Dr. Denis
   <arg name="use_mock"
        default="true"
        description="Choose if to start mock hardware or real hardware."/>
+  <arg name="sim_gazebo"
+       default="false"
+       description="Choose if to build the URDF for Gazebo simulation (gz_ros2_control)."/>
+  <arg name="simulation_controllers"
+       default=""
+       description="Path to the controllers YAML file, passed to the gz_ros2_control Gazebo plugin. Required when sim_gazebo is true."/>
   <arg name="robot_ip"
        default="192.168.28.28"
        description="IP address of the robot controller."/>
 
-  <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share $(var description_package))/urdf/$(var description_file).urdf.xacro prefix:=$(var prefix) attach_world:=$(var attach_world) use_mock:=$(var use_mock) robot_ip:=$(var robot_ip)')"/>
+  <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share $(var description_package))/urdf/$(var description_file).urdf.xacro prefix:=$(var prefix) attach_world:=$(var attach_world) use_mock:=$(var use_mock) sim_gazebo:=$(var sim_gazebo) simulation_controllers:=$(var simulation_controllers) robot_ip:=$(var robot_ip)')"/>
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
     <param name="robot_description" value="$(var robot_description_content)" />

--- a/templates/robot_description/robot_macro.ros2_control.xacro
+++ b/templates/robot_description/robot_macro.ros2_control.xacro
@@ -12,7 +12,7 @@
 
     <ros2_control name="${name}" type="system">
       <hardware>
-        <xacro:if value="${use_mock}">
+        <xacro:if value="${use_mock and not sim_gazebo}">
           <plugin>mock_components/GenericSystem</plugin>
           <param name="mock_sensor_commands">${mock_sensor_commands}</param>
         </xacro:if>

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -145,6 +145,41 @@ kill $PID_DESC
 PID_DESC=""
 sleep 5
 
+# Regression test: sim_gazebo/use_mock must select the Gazebo hardware plugin,
+# not the mock one, and must forward simulation_controllers into the URDF.
+echo -e "${TERMINAL_COLOR_BLUE}Launching my_robot_description load_description.launch.xml with sim_gazebo:=true...${TERMINAL_COLOR_NC}"
+ros2 launch my_robot_description load_description.launch.xml sim_gazebo:=true use_mock:=false simulation_controllers:=/tmp/dummy_controllers.yaml &
+PID_DESC=$!
+wait_for_robot_description 20 10 2
+
+echo -e "${TERMINAL_COLOR_YELLOW}Checking robot_description content for the Gazebo hardware plugin...${TERMINAL_COLOR_NC}"
+ROBOT_DESCRIPTION_CONTENT=$(ros2 topic echo /robot_description --once --timeout 10 2>/dev/null)
+
+if echo "$ROBOT_DESCRIPTION_CONTENT" | grep -q "gz_ros2_control/GazeboSimSystem"; then
+    echo -e "${TERMINAL_COLOR_GREEN}Success: GazeboSimSystem plugin present.${TERMINAL_COLOR_NC}"
+else
+    echo -e "${TERMINAL_COLOR_RED}Error: GazeboSimSystem plugin missing from robot_description with sim_gazebo:=true.${TERMINAL_COLOR_NC}"
+    exit 1
+fi
+
+if echo "$ROBOT_DESCRIPTION_CONTENT" | grep -q "mock_components/GenericSystem"; then
+    echo -e "${TERMINAL_COLOR_RED}Error: GenericSystem (mock) plugin still present with sim_gazebo:=true use_mock:=false.${TERMINAL_COLOR_NC}"
+    exit 1
+else
+    echo -e "${TERMINAL_COLOR_GREEN}Success: GenericSystem plugin correctly absent.${TERMINAL_COLOR_NC}"
+fi
+
+if echo "$ROBOT_DESCRIPTION_CONTENT" | grep -q "/tmp/dummy_controllers.yaml"; then
+    echo -e "${TERMINAL_COLOR_GREEN}Success: simulation_controllers path forwarded into robot_description.${TERMINAL_COLOR_NC}"
+else
+    echo -e "${TERMINAL_COLOR_RED}Error: simulation_controllers path missing from robot_description.${TERMINAL_COLOR_NC}"
+    exit 1
+fi
+
+kill $PID_DESC
+PID_DESC=""
+sleep 5
+
 # Test bringup launch
 echo -e "${TERMINAL_COLOR_BLUE}Launching my_robot_control start_offline.launch.xml...${TERMINAL_COLOR_NC}"
 ros2 launch my_robot_control start_offline.launch.xml &

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -153,7 +153,7 @@ PID_DESC=$!
 wait_for_robot_description 20 10 2
 
 echo -e "${TERMINAL_COLOR_YELLOW}Checking robot_description content for the Gazebo hardware plugin...${TERMINAL_COLOR_NC}"
-ROBOT_DESCRIPTION_CONTENT=$(ros2 topic echo /robot_description --once --timeout 10 2>/dev/null)
+ROBOT_DESCRIPTION_CONTENT=$(ros2 topic echo /robot_description --once --timeout 10 --full-length 2>/dev/null)
 
 if echo "$ROBOT_DESCRIPTION_CONTENT" | grep -q "gz_ros2_control/GazeboSimSystem"; then
     echo -e "${TERMINAL_COLOR_GREEN}Success: GazeboSimSystem plugin present.${TERMINAL_COLOR_NC}"

--- a/tests/run_tests.bash
+++ b/tests/run_tests.bash
@@ -141,9 +141,10 @@ ros2 launch my_robot_description load_description.launch.xml &
 PID_DESC=$!
 wait_for_robot_description 20 10 2
 
-kill $PID_DESC
+kill $PID_DESC 2>/dev/null || true
+wait $PID_DESC 2>/dev/null || true
 PID_DESC=""
-sleep 5
+sleep 2
 
 # Regression test: sim_gazebo/use_mock must select the Gazebo hardware plugin,
 # not the mock one, and must forward simulation_controllers into the URDF.
@@ -176,9 +177,10 @@ else
     exit 1
 fi
 
-kill $PID_DESC
+kill $PID_DESC 2>/dev/null || true
+wait $PID_DESC 2>/dev/null || true
 PID_DESC=""
-sleep 5
+sleep 2
 
 # Test bringup launch
 echo -e "${TERMINAL_COLOR_BLUE}Launching my_robot_control start_offline.launch.xml...${TERMINAL_COLOR_NC}"


### PR DESCRIPTION
## Summary
- `robot_macro.ros2_control.xacro`'s `<ros2_control>` hardware-plugin selection already supports mock/Gazebo/real via the `sim_gazebo`/`simulation_controllers` xacro args, but `load_description.launch.xml` — the file every `bringup_control.launch.{xml,py}` includes to build `robot_description` — never forwarded either one to the `xacro` command.
- Result: any launch file setting `sim_gazebo:=true` had no effect.
  The xacro always fell through to its file-default (`false`), so the URDF always picked the real-hardware plugin branch instead of `gz_ros2_control/GazeboSimSystem` — silently, no error anywhere.
  `gz_ros2_control` then had nothing to load in the simulation and never started a `controller_manager`.
- Fix: forward both args through, matching how `prefix`/`attach_world`/`use_mock`/`robot_ip` are already forwarded.

Verified with a scratch package generated via `setup-robot-description`: after this fix, `sim_gazebo:=true simulation_controllers:=<path>` correctly resolves `gz_ros2_control/GazeboSimSystem` with the given controllers file in the generated URDF.

Note: `bringup_control.launch.{xml,py}` itself still has no Gazebo launching (gz sim / entity spawn / clock bridge) — that's a separate, larger addition (a project's own launch file has to provide it, as ours currently does), not covered by this PR.

## Test plan
- [x] `create-new-package` + `setup-robot-description <name>` on a scratch package, confirm generated `load_description.launch.xml` forwards both args.
- [x] `xacro urdf/<name>.urdf.xacro sim_gazebo:=true simulation_controllers:=<path>` resolves `gz_ros2_control/GazeboSimSystem` with the given `<parameters>` path.
- [x] Default behavior (no args passed) unchanged — mock/real selection still works as before.
- [x] CI regression test added: launches with `sim_gazebo:=true use_mock:=false`, asserts `robot_description` contains `GazeboSimSystem` and the given `simulation_controllers` path, and not `GenericSystem`.
