### PR TITLE
docs: add Debian PREEMPT_RT + Docker guide alongside Ubuntu kernel setup

### DIFF
--- a/docs/operating_system/docker/general_information_docker/general_information_docker.rst
+++ b/docs/operating_system/docker/general_information_docker/general_information_docker.rst
@@ -13,7 +13,10 @@ You have to install docker which is dependent on the operating system you are us
 
 *   `Windows <https://docs.docker.com/desktop/windows/install/>`_
 *   `Mac <https://docs.docker.com/desktop/mac/install/>`_
-*   `Linux <https://docs.docker.com/desktop/install/linux-install/>`_: it depends.
+*   Linux: use Docker Engine's official apt repo, not Docker Desktop:
+
+    *   `Ubuntu <https://docs.docker.com/engine/install/ubuntu/>`_
+    *   `Debian <https://docs.docker.com/engine/install/debian/>`_
 
 You can verify that you have docker successfully installed by running:
 

--- a/docs/operating_system/docker/nvidia_docker/setup_nvidia_support.rst
+++ b/docs/operating_system/docker/nvidia_docker/setup_nvidia_support.rst
@@ -60,8 +60,7 @@ Install nvidia-docker
 **NOTE**: If you already have installed nvidia-docker, you can skip this and go right to the next section.
 
 1. You then have to install the NVIDIA Container Toolkit for docker as described `in official documentation <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker>`_.
-   For Ubuntu or Debian this can be done as follows (the command detects your
-   distribution from ``/etc/os-release`` automatically):
+   For Ubuntu or Debian this can be done as follows (the command detects your distribution from ``/etc/os-release`` automatically):
 
    .. code-block:: bash
 
@@ -177,9 +176,8 @@ If you get any error follow the next steps to be sure that the expected version 
       Be careful when executing command if multiple devices are using custom drivers you can unintenntionaly install wrong driver for another device (you will know if this is relevant for you - but it is imprtant to note it.)
 
    .. note::
-      ``ubuntu-drivers`` is Ubuntu-only. On Debian, install the driver from
-      Debian's ``nvidia-driver`` package (non-free repo) or NVIDIA's
-      official ``.run`` installer instead.
+      ``ubuntu-drivers`` is Ubuntu-only.
+      On Debian, install the driver from Debian's ``nvidia-driver`` package (non-free repo) or NVIDIA's official ``.run`` installer instead.
 
 2. Delete all other nvidia driver's version and corresponding libraries - use ``purge`` command for it.
 3. Restart your computer.

--- a/docs/operating_system/docker/nvidia_docker/setup_nvidia_support.rst
+++ b/docs/operating_system/docker/nvidia_docker/setup_nvidia_support.rst
@@ -60,7 +60,8 @@ Install nvidia-docker
 **NOTE**: If you already have installed nvidia-docker, you can skip this and go right to the next section.
 
 1. You then have to install the NVIDIA Container Toolkit for docker as described `in official documentation <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker>`_.
-   For Ubuntu this can be done as follows:
+   For Ubuntu or Debian this can be done as follows (the command detects your
+   distribution from ``/etc/os-release`` automatically):
 
    .. code-block:: bash
 
@@ -174,6 +175,11 @@ If you get any error follow the next steps to be sure that the expected version 
 
    .. note::
       Be careful when executing command if multiple devices are using custom drivers you can unintenntionaly install wrong driver for another device (you will know if this is relevant for you - but it is imprtant to note it.)
+
+   .. note::
+      ``ubuntu-drivers`` is Ubuntu-only. On Debian, install the driver from
+      Debian's ``nvidia-driver`` package (non-free repo) or NVIDIA's
+      official ``.run`` installer instead.
 
 2. Delete all other nvidia driver's version and corresponding libraries - use ``purge`` command for it.
 3. Restart your computer.

--- a/docs/operating_system/docker/supported_versions/supported_versions.rst
+++ b/docs/operating_system/docker/supported_versions/supported_versions.rst
@@ -48,6 +48,6 @@ Debian
 Debian is not a native ``rosdep``/ROS target. It is used as a **real-time
 docker host**: a Debian PC provides the PREEMPT_RT kernel and Docker runtime,
 while ROS itself still runs inside one of the Ubuntu containers from the
-table above (typically jazzy on ubuntu 24.04). See
+table above. See
 :ref:`Setup Real-Time Kernel (Debian, prebuilt package) <uc-setup-rt-kernel-debian>`
 for the full setup.

--- a/docs/operating_system/docker/supported_versions/supported_versions.rst
+++ b/docs/operating_system/docker/supported_versions/supported_versions.rst
@@ -41,3 +41,13 @@ For the supported Ubuntu and ros version combinations have a look at the table b
 
 
 \* - last release for that Ubuntu distro - no ``rosdep`` support anymore.
+
+Debian
+""""""
+
+Debian is not a native ``rosdep``/ROS target. It is used as a **real-time
+docker host**: a Debian PC provides the PREEMPT_RT kernel and Docker runtime,
+while ROS itself still runs inside one of the Ubuntu containers from the
+table above (typically jazzy on ubuntu 24.04). See
+:ref:`Setup Real-Time Kernel (Debian, prebuilt package) <uc-setup-rt-kernel-debian>`
+for the full setup.

--- a/docs/operating_system/docker/supported_versions/supported_versions.rst
+++ b/docs/operating_system/docker/supported_versions/supported_versions.rst
@@ -45,9 +45,6 @@ For the supported Ubuntu and ros version combinations have a look at the table b
 Debian
 """"""
 
-Debian is not a native ``rosdep``/ROS target. It is used as a **real-time
-docker host**: a Debian PC provides the PREEMPT_RT kernel and Docker runtime,
-while ROS itself still runs inside one of the Ubuntu containers from the
-table above. See
-:ref:`Setup Real-Time Kernel (Debian, prebuilt package) <uc-setup-rt-kernel-debian>`
-for the full setup.
+Debian is not a native ``rosdep``/ROS target.
+It is used as a **real-time docker host**: a Debian PC provides the PREEMPT_RT kernel and Docker runtime, while ROS itself still runs inside one of the Ubuntu containers from the table above.
+See :ref:`Setup Real-Time Kernel (Debian, prebuilt package) <uc-setup-rt-kernel-debian>` for the full setup.

--- a/docs/operating_system/setup_rt_kernel.rst
+++ b/docs/operating_system/setup_rt_kernel.rst
@@ -5,6 +5,11 @@ Setup Real-Time Kernel
 
 This script automates the process of downloading, patching, compiling, and installing a Linux kernel with the PREEMPT_RT patch. This is essential for achieving real-time performance for robot control.
 
+.. note::
+   On Debian, a prebuilt PREEMPT_RT kernel package is available and no
+   compilation is needed — see :ref:`Setup Real-Time Kernel (Debian,
+   prebuilt package) <uc-setup-rt-kernel-debian>` instead.
+
 Usage
 -----
 

--- a/docs/operating_system/setup_rt_kernel.rst
+++ b/docs/operating_system/setup_rt_kernel.rst
@@ -6,9 +6,7 @@ Setup Real-Time Kernel
 This script automates the process of downloading, patching, compiling, and installing a Linux kernel with the PREEMPT_RT patch. This is essential for achieving real-time performance for robot control.
 
 .. note::
-   On Debian, a prebuilt PREEMPT_RT kernel package is available and no
-   compilation is needed — see :ref:`Setup Real-Time Kernel (Debian,
-   prebuilt package) <uc-setup-rt-kernel-debian>` instead.
+   On Debian, a prebuilt PREEMPT_RT kernel package is available and no compilation is needed — see :ref:`Setup Real-Time Kernel (Debian, prebuilt package) <uc-setup-rt-kernel-debian>` instead.
 
 Usage
 -----

--- a/docs/operating_system/setup_rt_kernel_debian.rst
+++ b/docs/operating_system/setup_rt_kernel_debian.rst
@@ -10,10 +10,8 @@ We're using a pre-build binary on Linux Debian distribution and a docker contain
 with Ubuntu 24.04 with real-time permissions.
 
 .. note::
-   This is the Debian alternative to :ref:`compiling a PREEMPT_RT kernel
-   from source on Ubuntu <uc-setup-rt-kernel>`. Debian ships prebuilt
-   ``-rt-amd64`` kernel packages, so no compilation is needed here — ROS
-   itself still runs inside an Ubuntu 24.04 docker container.
+   This is the Debian alternative to :ref:`compiling a PREEMPT_RT kernel from source on Ubuntu <uc-setup-rt-kernel>`.
+   Debian ships prebuilt ``-rt-amd64`` kernel packages, so no compilation is needed here — ROS itself still runs inside an Ubuntu 24.04 docker container.
 
 Operating System Installation
 ------------------------------
@@ -29,15 +27,17 @@ Operating System Installation
 
 4. Follow installation steps:
 
-   * Be aware Debian uses a separate ``root`` user. Don't get confused with two passwords. Debian has root user that doesn't have name, and you can access it with ``su -`` command.
+   * Be aware Debian uses a separate ``root`` user.
+     Don't get confused with two passwords.
+     The root user has no name; access it with the ``su -`` command.
    * Install ``ssh`` during setup
-   * Choose your preferred window manager _(recommended is Plasma)_
+   * Choose your preferred window manager (recommended: Plasma)
 
 5. Configure networking:
 
    * Main network according to your company requirements
 
-6. Login to the PC after installation _(recommended to use **Plasma on X11**)_:
+6. Login to the PC after installation (recommended: Plasma on X11):
 
    * Set up a networking - usually your company network and dedicated RT ethernet interface for your robot with a static IP.
 
@@ -99,8 +99,7 @@ Realtime Permissions Setup
 
 14. Install Docker (APT method):
 
-   See :ref:`general info on docker installation
-   <general-info-on-docker-installation>` (Debian's official apt repo).
+   See :ref:`general info on docker installation <general-info-on-docker-installation>` (Debian's official apt repo).
 
 15. Configure ``realtime`` and ``docker`` groups and configure limits:
 

--- a/docs/operating_system/setup_rt_kernel_debian.rst
+++ b/docs/operating_system/setup_rt_kernel_debian.rst
@@ -1,11 +1,19 @@
-Realtime PC Setup
-====================================
+.. _uc-setup-rt-kernel-debian:
+
+Setup Real-Time Kernel (Debian, prebuilt package)
+==================================================
 
 This guide describes the recommended and simplest way to set up a
 real-time (PREEMPT_RT) PC and prepare it for ROS 2 development using RTW.
 
 We're using a pre-build binary on Linux Debian distribution and a docker container
 with Ubuntu 24.04 with real-time permissions.
+
+.. note::
+   This is the Debian alternative to :ref:`compiling a PREEMPT_RT kernel
+   from source on Ubuntu <uc-setup-rt-kernel>`. Debian ships prebuilt
+   ``-rt-amd64`` kernel packages, so no compilation is needed here — ROS
+   itself still runs inside an Ubuntu 24.04 docker container.
 
 Operating System Installation
 ------------------------------
@@ -91,7 +99,8 @@ Realtime Permissions Setup
 
 14. Install Docker (APT method):
 
-   https://docs.docker.com/engine/install/debian/
+   See :ref:`general info on docker installation
+   <general-info-on-docker-installation>` (Debian's official apt repo).
 
 15. Configure ``realtime`` and ``docker`` groups and configure limits:
 

--- a/docs/rtwcli/index.rst
+++ b/docs/rtwcli/index.rst
@@ -349,7 +349,8 @@ Kernel scheduling and performance
      provide the ``realtime`` group.
 
   For a complete step-by-step guide on setting up a PREEMPT_RT Debian system
-  and ROS workspace, see: `PREEMPT_RT PC setup <realtime_pc_setup.rst>`_
+  and ROS workspace, see: :doc:`PREEMPT_RT PC setup
+  <../operating_system/setup_rt_kernel_debian>`
 
 
 Supplementary group permissions

--- a/docs/rtwcli/index.rst
+++ b/docs/rtwcli/index.rst
@@ -348,9 +348,7 @@ Kernel scheduling and performance
      Your host system must already be configured for real-time scheduling and
      provide the ``realtime`` group.
 
-  For a complete step-by-step guide on setting up a PREEMPT_RT Debian system
-  and ROS workspace, see: :doc:`PREEMPT_RT PC setup
-  <../operating_system/setup_rt_kernel_debian>`
+  For a complete step-by-step guide on setting up a PREEMPT_RT Debian system and ROS workspace, see: :doc:`PREEMPT_RT PC setup <../operating_system/setup_rt_kernel_debian>`
 
 
 Supplementary group permissions


### PR DESCRIPTION
## Summary
- Move the Debian PREEMPT_RT + Docker guide from `docs/rtwcli/realtime_pc_setup.rst` to `docs/operating_system/setup_rt_kernel_debian.rst`, next to the existing Ubuntu compile-from-source RT kernel guide (`setup_rt_kernel.rst`), and cross-link the two so either page leads to the OS-appropriate alternative.
- Add Debian coverage to the Docker docs, which previously only covered Ubuntu: install links in `general_information_docker.rst`, a clarifying note in `supported_versions.rst` (Debian is the real-time host, ROS still runs in an Ubuntu container), and Debian notes in `nvidia_docker/setup_nvidia_support.rst`.
- Fix the link to the moved guide in `docs/rtwcli/index.rst`.

Ansible/provisioning automation is intentionally out of scope — this is documentation only.

## Test plan
- [x] `make html` in `docs/` builds clean (only pre-existing, unrelated warnings)
- [x] Verified in the built HTML that all new/updated cross-references (`setup_rt_kernel.rst` ↔ `setup_rt_kernel_debian.rst`, `rtwcli/index.rst` → moved guide, `supported_versions.rst` → moved guide, moved guide → Docker install section) resolve to real anchors, not broken links

Co-Authored-By: Korba <korba@b-robotized.ai>