### PR TITLE
docs: fix Debian claims Copilot flagged post-merge on #332

### DIFF
--- a/docs/operating_system/docker/nvidia_docker/setup_nvidia_support.rst
+++ b/docs/operating_system/docker/nvidia_docker/setup_nvidia_support.rst
@@ -60,13 +60,12 @@ Install nvidia-docker
 **NOTE**: If you already have installed nvidia-docker, you can skip this and go right to the next section.
 
 1. You then have to install the NVIDIA Container Toolkit for docker as described `in official documentation <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html#docker>`_.
-   For Ubuntu or Debian this can be done as follows (the command detects your distribution from ``/etc/os-release`` automatically):
+   For Ubuntu or Debian this can be done as follows (NVIDIA's repository is not distribution-specific, the same steps work for both):
 
    .. code-block:: bash
 
-      distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-         && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
-         && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+      curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+         && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
             sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
             sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
@@ -186,7 +185,7 @@ If you get any error follow the next steps to be sure that the expected version 
    1. Close your eyes and breathe slowely in and out at least once :)
    2. You probably didn't install everything properly so the open-source ``nouveau`` driver is used which is not adequate for this scenario.
    3. Use ``<CTRL> + <ALT> + <F2-3-4...>`` keys to switch to a linux terminal.
-   4. Login there and execute ``ubuntu-drivers`` command to install missing drivers.
+   4. Login there and install the missing driver: on Ubuntu, execute the ``ubuntu-drivers`` command; on Debian, use whichever install path you chose above (the ``nvidia-driver`` package or NVIDIA's ``.run`` installer).
    5. Now restart again and everything should work properly.
 
 5. Now check again output of the ``ṅvidia-smi`` command

--- a/docs/operating_system/docker/supported_versions/supported_versions.rst
+++ b/docs/operating_system/docker/supported_versions/supported_versions.rst
@@ -45,6 +45,6 @@ For the supported Ubuntu and ros version combinations have a look at the table b
 Debian
 """"""
 
-Debian is not a native ``rosdep``/ROS target.
+Debian has no native ROS binary distribution — the Ubuntu/ROS combinations in the table above don't apply to it directly.
 It is used as a **real-time docker host**: a Debian PC provides the PREEMPT_RT kernel and Docker runtime, while ROS itself still runs inside one of the Ubuntu containers from the table above.
 See :ref:`Setup Real-Time Kernel (Debian, prebuilt package) <uc-setup-rt-kernel-debian>` for the full setup.


### PR DESCRIPTION
## Summary
Copilot reviewed #332 after it was already merged and flagged three real issues in the Debian Docker docs it added. Addresses all three:

- `supported_versions.rst`: "Debian is not a native `rosdep`/ROS target" conflates rosdep/apt support (which Debian has) with the actual point — Debian has no native ROS binary distribution, so the Ubuntu/ROS combinations in the table don't apply to it directly. Reworded.
- `setup_nvidia_support.rst`: the install command built a distribution-specific repo URL (`.../$distribution/libnvidia-container.list`) from `/etc/os-release`. NVIDIA's current install guide uses a single unified URL (`.../stable/deb/nvidia-container-toolkit.list`) instead — the old per-distribution URL can 404 on newer Debian releases. Verified against NVIDIA's current docs.
- `setup_nvidia_support.rst`: the driver-recovery troubleshooting step unconditionally told readers to run the Ubuntu-only `ubuntu-drivers` command, even on Debian. Made OS-specific.

## Test plan
- [x] `make html` builds clean, no new warnings on the touched files.
- [x] NVIDIA unified repo URL confirmed against their current install guide (`docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html`).

Refs #332.
