### PR TITLE
Fix package-creation bugs around proprietary license text and GitLab repos

### DIFF
--- a/scripts/_RosTeamWs_Defines.bash
+++ b/scripts/_RosTeamWs_Defines.bash
@@ -535,8 +535,11 @@ let_user_select_license() {
     "$licence_proprietary")
       read -p "Enter name of license (e.g. 'Proprietary License'): " NAME_OF_LICENSE
       YEAR=$(date +'%Y')
+      # Escape sed replacement-text metacharacters (& = whole match, \ = escape)
+      # so a holder name like "Vorwerk Elektrowerke GmbH & Co. KG" isn't corrupted.
+      NAME_OF_LICENSE_ESCAPED=$(printf '%s' "${NAME_OF_LICENSE}" | sed -e 's/[&\]/\\&/g')
       license=$(<"${LICENSE_TEMPLATES}/proprietary_company_header.txt")
-      license=$(echo "${license}" | sed -e "s/\\\$YEAR\\\$/${YEAR}/g; s/\\\$NAME_ON_LICENSE\\\$/${NAME_OF_LICENSE}/g")
+      license=$(echo "${license}" | sed -e "s/\\\$YEAR\\\$/${YEAR}/g; s/\\\$NAME_ON_LICENSE\\\$/${NAME_OF_LICENSE_ESCAPED}/g")
       break
       ;;
     *)

--- a/scripts/create-new-package.bash
+++ b/scripts/create-new-package.bash
@@ -237,7 +237,7 @@ case "$choice" in
       cd $PKG_NAME
     fi
 
-    $RosTeamWS_FRAMEWORK_SCRIPTS_PATH/setup-repository.bash $PKG_NAME "$PKG_DESCRIPTION" $LICENSE
+    $RosTeamWS_FRAMEWORK_SCRIPTS_PATH/setup-repository.bash $PKG_NAME "$PKG_DESCRIPTION" "$LICENSE"
 
   else
 

--- a/scripts/setup-repository.bash
+++ b/scripts/setup-repository.bash
@@ -87,7 +87,8 @@ case "$choice" in
   ;;
 "2")
   cp --update=none $PACKAGE_TEMPLATES/.gitlab-ci.yml .
-  cp --update=none $PACKAGE_TEMPLATES/.ci.repos .
+  cp --update=none $PACKAGE_TEMPLATES/pkg_name.repos .ci.repos
+  cp --update=none $PACKAGE_TEMPLATES/README.md.gitlab README.md
   repository="gitlab"
   ;;
 *)
@@ -125,12 +126,19 @@ read -p "Enter namespace of the repository [default: $PKG_NAME]: " NAMESPACE
 NAMESPACE=${NAMESPACE:=$PKG_NAME}
 
 license_web="${LICENSE// /%20}"
-sed -i 's/\$NAME\$/'${PKG_NAME}'/g' README.md
-sed -i 's/\$ROS_DISTRO\$/'${ros_distro}'/g' README.md
-sed -i 's/\$Ros_distro\$/'${ros_distro^}'/g' README.md
-sed -i 's/\$DESCRIPTION\$/'"${PKG_DESCRIPTION}"'/g' README.md
-sed -i 's/\$LICENSE\$/'${license_web}'/g' README.md
-sed -i 's/\$NAMESPACE\$/'${NAMESPACE}'/g' README.md
+# Use '|' as the sed delimiter (not '/', which NAMESPACE and DESCRIPTION can
+# contain, e.g. a GitLab "group/subproject" namespace) and escape '&'/'\'/'|'
+# in each replacement value, so it can't be read as a sed backreference or
+# break the substitution (e.g. a proprietary license holder with '&' in it).
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[&\|]/\\&/g'
+}
+sed -i 's|\$NAME\$|'"$(escape_sed_replacement "${PKG_NAME}")"'|g' README.md
+sed -i 's|\$ROS_DISTRO\$|'"$(escape_sed_replacement "${ros_distro}")"'|g' README.md
+sed -i 's|\$Ros_distro\$|'"$(escape_sed_replacement "${ros_distro^}")"'|g' README.md
+sed -i 's|\$DESCRIPTION\$|'"$(escape_sed_replacement "${PKG_DESCRIPTION}")"'|g' README.md
+sed -i 's|\$LICENSE\$|'"$(escape_sed_replacement "${license_web}")"'|g' README.md
+sed -i 's|\$NAMESPACE\$|'"$(escape_sed_replacement "${NAMESPACE}")"'|g' README.md
 
 # Check if it is metapackage
 if [[ ! -f "package.xml" ]]; then


### PR DESCRIPTION
## Summary
- `let_user_select_license`: escape sed metacharacters (`&`, `\`) in the proprietary-license holder name before substitution — an unescaped `&` (e.g. "Vorwerk Elektrowerke GmbH & Co. KG") was read by sed as "insert the matched text", corrupting the generated `<license>` line in `package.xml`.
- `create-new-package.bash`: quote `$LICENSE` when passing it to `setup-repository.bash` — unquoted, a multi-word license word-split across positional params, so `setup-repository.bash` silently only saw the license's first word.
- `setup-repository.bash`: copy `README.md.gitlab` on the GitLab path, matching the GitHub path's `README.md.github` copy — previously a GitLab-hosted package got no README at all.
- `setup-repository.bash`: fix the README templating `sed` calls, which had silently been no-ops on every package (no README.md existed to edit, until the fix above). They used `/` as the sed delimiter while substituting values that can contain `/` (e.g. a GitLab `group/subgroup` namespace), and passed values unescaped for `&`. Switched to `|` as the delimiter and escape each replacement value.
- `setup-repository.bash`: point `.ci.repos` at the existing generic `pkg_name.repos` template instead of a template file that doesn't exist (the `cp` was silently failing every time).

All five bugs were hit in the same session, creating two real packages for a client project with a proprietary license holder containing `&` and a GitLab namespace containing `/`.

## Test plan
- [x] Ran `create-new-package` end to end with a proprietary license holder containing `&` (`Vorwerk Elektrowerke GmbH & Co. KG`), the GitLab repository-server option, and a namespace containing `/` (`test/ns`) — confirmed `package.xml`'s `<license>` line and `README.md`'s placeholder substitutions are both correct, no sed errors.
- [x] Confirmed `.ci.repos` and `README.md` are now created on the GitLab path.