### PR TITLE
Add Isaac Sim option to the robot_description ros2_control template

### DIFF
--- a/templates/robot_description/append_to_README.md
+++ b/templates/robot_description/append_to_README.md
@@ -58,3 +58,35 @@ ros2 launch $PKG_NAME$ view_$ROBOT_NAME$.launch.py
 
 If there are no issues with the description, two windows are opened: `rviz2` and `Joint State Publisher`.
 Rviz2 visualizes the robot's state and Joint state Publisher to changes joint values using sliders or generates random but valid configurations.
+
+### Controlling the robot through Isaac Sim
+
+`<robot_name>_macro.ros2_control.xacro`'s `use_isaac` option wires the robot up to
+[`topic_based_ros2_control`](https://github.com/PickNikRobotics/topic_based_ros2_control)'s
+`TopicBasedSystem` instead of a real or mock hardware interface — no custom hardware
+interface is needed, `TopicBasedSystem` just reads/writes whatever joint states/commands
+an Isaac Sim Action Graph publishes/subscribes on `isaac_joint_states_topic` /
+`isaac_joint_commands_topic`. If the robot has an FT sensor, it comes through as a
+*separate* `<ros2_control type="sensor">` component using
+[`topic_based_ft_ros2_control`](https://github.com/PickNikRobotics/topic_based_ft_ros2_control)
+on `isaac_ft_wrench_topic` — `TopicBasedSystem` can't carry a nested `<sensor>`, so this
+can't be folded into the main block the way a real hardware interface's FT sensor is.
+
+Whatever package brings this description up with Isaac needs `topic_based_ros2_control`
+(and `topic_based_ft_ros2_control`, if using the FT sensor block) as a dependency and in
+its workspace `.repos` file — this description package intentionally doesn't declare
+them, the same way it doesn't declare `mock_components`/`gz_ros2_control`/the real
+hardware interface package either.
+
+Two gotchas worth knowing before debugging either one from scratch:
+
+- **Multiple robots in one Isaac scene**: Isaac can't tell apart identically-named joints
+  on two robot prims of the same type, so `isaac_joint_commands_topic` /
+  `isaac_joint_states_topic` / `isaac_ft_wrench_topic` must be overridden per robot
+  (typically per `prefix`), and the Isaac-side Action Graph needs its joint names fed in
+  explicitly rather than read from the topic.
+- **Stale commands across controller switches**: `TopicBasedSystem::write()` republishes
+  every command field every cycle, regardless of which controller currently claims it —
+  nothing clears a field when its owning controller is deactivated. If more than one
+  controller type (e.g. position and effort) can be active on the same joints, add a
+  small node that gates which command field Isaac's Action Graph should honor.

--- a/templates/robot_description/load_description.launch.xml
+++ b/templates/robot_description/load_description.launch.xml
@@ -34,11 +34,14 @@ Author: Dr. Denis
   <arg name="use_mock"
        default="true"
        description="Choose if to start mock hardware or real hardware."/>
+  <arg name="use_isaac"
+       default="false"
+       description="Choose if to control the robot through Isaac Sim (topic_based_ros2_control) instead of mock/real hardware."/>
   <arg name="robot_ip"
        default="192.168.28.28"
        description="IP address of the robot controller."/>
 
-  <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share $(var description_package))/urdf/$(var description_file).urdf.xacro prefix:=$(var prefix) attach_world:=$(var attach_world) use_mock:=$(var use_mock) robot_ip:=$(var robot_ip)')"/>
+  <let name="robot_description_content" value="$(command '$(find-exec xacro) $(find-pkg-share $(var description_package))/urdf/$(var description_file).urdf.xacro prefix:=$(var prefix) attach_world:=$(var attach_world) use_mock:=$(var use_mock) use_isaac:=$(var use_isaac) robot_ip:=$(var robot_ip)')"/>
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
     <param name="robot_description" value="$(var robot_description_content)" />

--- a/templates/robot_description/robot.urdf.xacro
+++ b/templates/robot_description/robot.urdf.xacro
@@ -9,6 +9,10 @@
   <xacro:arg name="mock_sensor_commands" default="false"/>
   <xacro:arg name="sim_gazebo" default="false"/>
   <xacro:arg name="simulation_controllers" default=""/>
+  <xacro:arg name="use_isaac" default="false"/>
+  <xacro:arg name="isaac_joint_commands_topic" default="/isaac/joint_commands"/>
+  <xacro:arg name="isaac_joint_states_topic" default="/isaac/joint_states"/>
+  <xacro:arg name="isaac_ft_wrench_topic" default="/isaac/ft_sensor/wrench"/>
 
   <xacro:include filename="$(find $PKG_NAME$)/urdf/$ROBOT_NAME$/$ROBOT_NAME$_macro.xacro"/>
   <xacro:include filename="$(find $PKG_NAME$)/urdf/$ROBOT_NAME$/$ROBOT_NAME$_macro.ros2_control.xacro"/>
@@ -38,6 +42,10 @@
     use_mock="$(arg use_mock)"
     mock_sensor_commands="$(arg mock_sensor_commands)"
     sim_gazebo="$(arg sim_gazebo)"
-    simulation_controllers="$(arg simulation_controllers)"/>
+    simulation_controllers="$(arg simulation_controllers)"
+    use_isaac="$(arg use_isaac)"
+    isaac_joint_commands_topic="$(arg isaac_joint_commands_topic)"
+    isaac_joint_states_topic="$(arg isaac_joint_states_topic)"
+    isaac_ft_wrench_topic="$(arg isaac_ft_wrench_topic)"/>
 
 </robot>

--- a/templates/robot_description/robot_macro.ros2_control.xacro
+++ b/templates/robot_description/robot_macro.ros2_control.xacro
@@ -7,7 +7,11 @@
                use_mock:=false
                mock_sensor_commands:=false
                sim_gazebo:=false
-               simulation_controllers"
+               simulation_controllers
+               use_isaac:=false
+               isaac_joint_commands_topic:=/isaac/joint_commands
+               isaac_joint_states_topic:=/isaac/joint_states
+               isaac_ft_wrench_topic:=/isaac/ft_sensor/wrench"
                >
 
     <ros2_control name="${name}" type="system">
@@ -19,7 +23,17 @@
         <xacro:if value="${sim_gazebo}">
           <plugin>gz_ros2_control/GazeboSimSystem</plugin>
         </xacro:if>
-        <xacro:unless value="${use_mock or sim_gazebo}">
+        <!-- Isaac Sim: no custom hardware interface needed, TopicBasedSystem
+             reads/writes whatever an Isaac Sim Action Graph publishes/subscribes
+             on these topics. Override the topics per robot when more than one
+             robot shares the same Isaac scene (Isaac can't tell identically-named
+             joints on two robots apart, so each robot needs its own topic pair). -->
+        <xacro:if value="${use_isaac}">
+          <plugin>topic_based_ros2_control/TopicBasedSystem</plugin>
+          <param name="joint_commands_topic">${isaac_joint_commands_topic}</param>
+          <param name="joint_states_topic">${isaac_joint_states_topic}</param>
+        </xacro:if>
+        <xacro:unless value="${use_mock or sim_gazebo or use_isaac}">
           <plugin>robot_hardware_interface/RobotHardwareInterface</plugin>
         </xacro:unless>
       </hardware>
@@ -89,28 +103,52 @@
         <state_interface name="velocity"/>
         <state_interface name="acceleration"/>
       </joint>
-      <sensor name="tcp_fts_sensor">            <!-- Remove/change sensors as needed -->
-        <state_interface name="fx"/>
-        <state_interface name="fy"/>
-        <state_interface name="fz"/>
-        <state_interface name="tx"/>
-        <state_interface name="ty"/>
-        <state_interface name="tz"/>
-        <param name="frame_id">tool0</param>    <!-- Change sensors as needed -->
-        <param name="min_fx">-100</param>
-        <param name="max_fx">100</param>
-        <param name="min_fy">-100</param>
-        <param name="max_fy">100</param>
-        <param name="min_fz">-200</param>
-        <param name="max_fz">200</param>
-        <param name="min_tx">-10</param>
-        <param name="max_tx">10</param>
-        <param name="min_ty">-10</param>
-        <param name="max_ty">10</param>
-        <param name="min_tz">-15</param>
-        <param name="max_tz">15</param>
-      </sensor>
+      <!-- Isaac Sim: TopicBasedSystem (above) cannot carry a nested <sensor> -
+           see the separate FrankaFtSensorInterface-style component below instead. -->
+      <xacro:unless value="${use_isaac}">
+        <sensor name="tcp_fts_sensor">            <!-- Remove/change sensors as needed -->
+          <state_interface name="fx"/>
+          <state_interface name="fy"/>
+          <state_interface name="fz"/>
+          <state_interface name="tx"/>
+          <state_interface name="ty"/>
+          <state_interface name="tz"/>
+          <param name="frame_id">tool0</param>    <!-- Change sensors as needed -->
+          <param name="min_fx">-100</param>
+          <param name="max_fx">100</param>
+          <param name="min_fy">-100</param>
+          <param name="max_fy">100</param>
+          <param name="min_fz">-200</param>
+          <param name="max_fz">200</param>
+          <param name="min_tx">-10</param>
+          <param name="max_tx">10</param>
+          <param name="min_ty">-10</param>
+          <param name="max_ty">10</param>
+          <param name="min_tz">-15</param>
+          <param name="max_tz">15</param>
+        </sensor>
+      </xacro:unless>
     </ros2_control>
+
+    <!-- Isaac Sim: FT sensor as its own hardware component, since
+         topic_based_ros2_control's TopicBasedSystem can't carry a nested
+         <sensor>. Remove this block if the robot has no FT sensor in Isaac. -->
+    <xacro:if value="${use_isaac}">
+      <ros2_control name="${name}_ft_sensor" type="sensor">
+        <hardware>
+          <plugin>topic_based_ft_ros2_control/TopicBasedFtSensor</plugin>
+          <param name="wrench_topic">${isaac_ft_wrench_topic}</param>
+        </hardware>
+        <sensor name="${prefix}tcp_fts_sensor">
+          <state_interface name="force.x"/>
+          <state_interface name="force.y"/>
+          <state_interface name="force.z"/>
+          <state_interface name="torque.x"/>
+          <state_interface name="torque.y"/>
+          <state_interface name="torque.z"/>
+        </sensor>
+      </ros2_control>
+    </xacro:if>
 
     <xacro:if value="$(arg sim_gazebo)">
       <!-- Gazebo plugins -->


### PR DESCRIPTION
## Summary
- `robot_macro.ros2_control.xacro` gets a fourth hardware branch alongside mock/gazebo/real: `use_isaac`, which selects `topic_based_ros2_control/TopicBasedSystem` instead of a custom hardware interface. No custom interface is needed for Isaac — `TopicBasedSystem` just reads/writes whatever an Isaac Sim Action Graph publishes/subscribes on `isaac_joint_commands_topic` / `isaac_joint_states_topic`.
- `TopicBasedSystem` can't carry a nested `<sensor>` the way a real hardware interface can, so an FT sensor (present in the template already, for the other three branches) becomes its own `<ros2_control type="sensor">` component under Isaac, using `topic_based_ft_ros2_control` on `isaac_ft_wrench_topic` — this is the separate hardware-interface component a topic-based Isaac setup needs.
- `robot.urdf.xacro` and `load_description.launch.xml` wire the new args through, matching how `use_mock`/`sim_gazebo` are already wired.
- `append_to_README.md` documents the option plus two gotchas worth knowing before debugging either from scratch: per-robot topic overrides when multiple robots share one Isaac scene (Isaac can't disambiguate identically-named joints across robot prims), and a stale-command node needed when more than one controller type can be active on the same joints (`TopicBasedSystem::write()` republishes every command field every cycle, regardless of which controller holds it).
- This description package intentionally still doesn't declare `topic_based_ros2_control`/`topic_based_ft_ros2_control` as dependencies, matching the existing precedent of not declaring `mock_components`/`gz_ros2_control`/the real hardware interface package either — the consuming project's own `package.xml` and `.repos` file own that.

Design pattern (off-the-shelf plugin over a topic bridge, not a custom hardware interface) confirmed against a real client project (`gasket_assembly_configuration` in the `aid4sme` workspace, commit `3c56943 "Use topic_based_ros2_control to control arms in Isaac Sim"`), generalized here so any new RTW-scaffolded robot description package gets the option without re-deriving it from scratch.

## Test plan
- [x] xacro-processed the generated `robot.urdf.xacro` standalone with `use_isaac:=true` — confirmed the `TopicBasedSystem` plugin and the separate FT sensor component render correctly, well-formed XML.
- [x] Same with the default mock path — confirmed no regression (nested FT sensor still present, unaffected).
- [x] Ran `setup-robot-description` end to end in a fresh package — `colcon build` succeeded, and the generated URDF (with `use_isaac:=true`) passed `check_urdf`.