### PR TITLE
Add TfPublisher to move group config template

### DIFF
--- a/templates/moveit/config/move_group_config.yaml
+++ b/templates/moveit/config/move_group_config.yaml
@@ -26,6 +26,7 @@
         move_group/MoveGroupExecuteTrajectoryAction
         pilz_industrial_motion_planner/MoveGroupSequenceAction
         pilz_industrial_motion_planner/MoveGroupSequenceService
+        move_group/TfPublisher
 
     # Trajectory execution manager parameters
     allow_trajectory_execution: true


### PR DESCRIPTION
`TfPublisher `is required to provide the TF frames for planning scene objects within MoveGroup. Therefore, it has been added to the MoveIt configuration template.